### PR TITLE
Custom scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V1.1.4
+
+add custom scope option
+
 ## V1.1.3
 
 Fix typo in documentation

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ After installation, you must add the following configuration in your waka.config
                 'urlAuthorize' => 'https:#myserver/auth/realms/master/protocol/openid-connect/auth',
                 'urlAccessToken' => 'https:#myserver/auth/realms/master/protocol/openid-connect/token',
                 'urlResourceOwnerDetails' => 'https:#myserver/auth/realms/master/protocol/openid-connect/userinfo',
+                // optionnal set custom scope for openid token. Default to openid
+                'scope' => 'openid custom_scope',
             ],
             // sso server fieldname used for the user id, this field links an SSO user to a yeswiki user
             'id_sso_field' => 'id',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ After installation, you must add the following configuration in your waka.config
                 'urlAccessToken' => 'https:#myserver/auth/realms/master/protocol/openid-connect/token',
                 'urlResourceOwnerDetails' => 'https:#myserver/auth/realms/master/protocol/openid-connect/userinfo',
                 // optionnal set custom scope for openid token. Default to openid
-                'scope' => 'openid custom_scope',
+                'scope' => ['openid', 'custom_scope'],
+                 // optionnal set custom scope seperator. Default to ' '
+                'scopeSeparator' => ' ',
             ],
             // sso server fieldname used for the user id, this field links an SSO user to a yeswiki user
             'id_sso_field' => 'id',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After installation, you must add the following configuration in your waka.config
                 'urlAccessToken' => 'https:#myserver/auth/realms/master/protocol/openid-connect/token',
                 'urlResourceOwnerDetails' => 'https:#myserver/auth/realms/master/protocol/openid-connect/userinfo',
                 // optionnal set custom scope for openid token. Default to openid
-                'scope' => ['openid', 'custom_scope'],
+                'scopes' => ['openid', 'custom_scope'],
                  // optionnal set custom scope seperator. Default to ' '
                 'scopeSeparator' => ' ',
             ],

--- a/desc.xml
+++ b/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<plugin name="wkloginsso" version="0.9" active="1">
+<plugin name="wkloginsso" version="1.1.4" active="1">
   <author>Adrien Cheype <adrien.cheype@gmail.com></author>
   <author>Florian Schmitt <mrflos@lilo.org></author>
   <label>Identification via un serveur d'authentification unique (SSO)</label>

--- a/services/OAuth2ProviderFactory.php
+++ b/services/OAuth2ProviderFactory.php
@@ -24,7 +24,7 @@ class OAuth2ProviderFactory
             'urlAuthorize' => $confEntry['auth_options']['urlAuthorize'],
             'urlAccessToken' => $confEntry['auth_options']['urlAccessToken'],
             'urlResourceOwnerDetails' => $confEntry['auth_options']['urlResourceOwnerDetails'],
-            'scopes' => ['openid'],
+            'scopes' => [ $confEntry['auth_options']['scope'] ] ?? ['openid'],
         ]);
     }
 }

--- a/services/OAuth2ProviderFactory.php
+++ b/services/OAuth2ProviderFactory.php
@@ -24,7 +24,7 @@ class OAuth2ProviderFactory
             'urlAuthorize' => $confEntry['auth_options']['urlAuthorize'],
             'urlAccessToken' => $confEntry['auth_options']['urlAccessToken'],
             'urlResourceOwnerDetails' => $confEntry['auth_options']['urlResourceOwnerDetails'],
-            'scopes' => $confEntry['auth_options']['scope'] ?? [ 'openid' ],
+            'scopes' => $confEntry['auth_options']['scopes'] ?? [ 'openid' ],
             'scopeSeparator' => $confEntry['auth_options']['scopeSeparator'] ?? ' '
         ]);
     }

--- a/services/OAuth2ProviderFactory.php
+++ b/services/OAuth2ProviderFactory.php
@@ -24,7 +24,8 @@ class OAuth2ProviderFactory
             'urlAuthorize' => $confEntry['auth_options']['urlAuthorize'],
             'urlAccessToken' => $confEntry['auth_options']['urlAccessToken'],
             'urlResourceOwnerDetails' => $confEntry['auth_options']['urlResourceOwnerDetails'],
-            'scopes' => [ $confEntry['auth_options']['scope'] ] ?? ['openid'],
+            'scopes' => $confEntry['auth_options']['scope'] ?? [ 'openid' ],
+            'scopeSeparator' => $confEntry['auth_options']['scopeSeparator'] ?? ' '
         ]);
     }
 }


### PR DESCRIPTION


Trying to connect YesWiki with Wordpress with the following [plugin](https://wordpress.org/plugins/miniorange-login-with-eve-online-google-facebook/).

I was unable to connect due to insufficient scope. Studying code, i discovered that scope is hard-coded.

This PR offer to keep 'openid' scope as default but add ability to set custom scope.
