### PR TITLE
fix(login): Add option to activate or not equal sign on callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After installation, you must add the following configuration in your waka.config
                 'scopes' => ['openid', 'custom_scope'],
                  // optionnal set custom scope seperator. Default to ' '
                 'scopeSeparator' => ' ',
+                // optionnal add a final equal to the redirect uri. Somme providers need it, some don't. Default to yes
+                'addFinalEqual' => true,
             ],
             // sso server fieldname used for the user id, this field links an SSO user to a yeswiki user
             'id_sso_field' => 'id',
@@ -154,7 +156,9 @@ After installation, you must add the following configuration in your waka.config
 
 You must configure the OIDC server to accept the redirection from your YesWiki instance.
 Add the following URL to the list of allowed redirections:
-`https://[wiki]/?api/auth_sso/callback=`
+
+If `addFinalEqual` is set to true or not defined, the URL must be `https://[wiki]/?api/auth_sso/callback=` otherwise it must be
+`https://[wiki]/?api/auth_sso/callback`
 
 ## TODO
 

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -60,8 +60,12 @@ class ApiController extends YesWikiController
             ]);
 
             $ssoUser = $provider->getResourceOwner($token)->toArray();
-        } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
-            Flash::error(_t('SSO_ERROR') . '. ' . _t('SSO_ERROR_DETAIL') . join(', ', $e->getResponseBody()));
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
+            if($e instanceof \League\OAuth2\Client\Provider\Exception\IdentityProviderException) {
+                $message = join(', ', $e->getResponseBody());
+            }
+            Flash::error(_t('SSO_ERROR') . '. ' . _t('SSO_ERROR_DETAIL') . $message);
             $this->wiki->redirect($incomingurl);
 
             return;

--- a/services/OAuth2ProviderFactory.php
+++ b/services/OAuth2ProviderFactory.php
@@ -17,10 +17,15 @@ class OAuth2ProviderFactory
     {
         $confEntry = $this->wiki->config['sso_config']['providers'][$providerId]; // TODO: multiple providers
 
+        $redirectUri = $this->wiki->getBaseUrl() . '/?api/auth_sso/callback';
+        if($confEntry['auth_options']['addFinalEqual'] ?? true) {
+            $redirectUri .= '=';
+        }
+
         return new \League\OAuth2\Client\Provider\GenericProvider([
             'clientId' => $confEntry['auth_options']['clientId'],    // The client ID assigned to you by the provider
             'clientSecret' => $confEntry['auth_options']['clientSecret'],   // The client password assigned to you by the provider
-            'redirectUri' => $this->wiki->getBaseUrl() . '/?api/auth_sso/callback=', // Final '=' mandatory for lemonldap compatibility
+            'redirectUri' => $redirectUri,
             'urlAuthorize' => $confEntry['auth_options']['urlAuthorize'],
             'urlAccessToken' => $confEntry['auth_options']['urlAccessToken'],
             'urlResourceOwnerDetails' => $confEntry['auth_options']['urlResourceOwnerDetails'],


### PR DESCRIPTION
In the OIDC protocol, the server must return to a callback URL adding some informations as query params.
As yeswiki route API callback URL via query params too, some servers may be confused.

This pull request allow to choose between `https://[wiki]/?api/auth_sso/callback=` and `https://[wiki]/?api/auth_sso/callback` in callback URL sent to servers. It does not change the way Yeswiki manage callbacks, but help OIDC servers to build the query params.
